### PR TITLE
remove .lower() call when generating in-file timestamp

### DIFF
--- a/nowbutton.py
+++ b/nowbutton.py
@@ -80,7 +80,7 @@ class MainWindowExtension(WindowExtension):
 
 		name=str(calendar_namespace.child(offset_time.strftime('%Y:%m:%d')));
 
-		text = '\n%s ' % strftime(self.plugin.preferences['timestamp_format']).lower();
+		text = '\n%s ' % strftime(self.plugin.preferences['timestamp_format']);
 
 		ui = self.window.ui
 		try:


### PR DESCRIPTION
For test logging purposes at work, I need to insert the timezone into my timestamps (via the strftime %Z operator). As written, the lower() call converts these stamps to lowercase- for instance, while I expect the format string "%H:%M:%S %Z" to produce "16:04:36 PDT", it actually produces "16:04:36 pdt". This is inconsistent with other zim timestamps which do not change the case of alphabetical letters in generated timestamps.

This fix corrects this oversight and brings us closer to the existing Zim behavior. You may also wish to look into these potentially unnecessary semicolons in a later revision :)